### PR TITLE
Bugfix: Tree Capacity

### DIFF
--- a/prioritized_memory.py
+++ b/prioritized_memory.py
@@ -5,6 +5,9 @@ from sum_tree import SumTree
 
 class Memory:  # stored as ( s, a, r, s_ ) in SumTree
     def __init__(self, capacity, alpha=0.6, beta=0.4, beta_anneal_step=0.001, epsilon=0.00000001):
+        tree_capacity = 1
+        while tree_capacity < size:
+            tree_capacity *= 2
         self.tree = SumTree(capacity)
         self.capacity = capacity
         self.a = alpha

--- a/sum_tree.py
+++ b/sum_tree.py
@@ -7,6 +7,7 @@ class SumTree:
     write = 0
 
     def __init__(self, capacity):
+        assert capacity > 0 and capacity & (capacity - 1) == 0, "capacity must be positive and a power of 2."
         self.capacity = capacity
         self.tree = numpy.zeros(2 * capacity - 1)
         self.data = numpy.zeros(capacity, dtype=object)


### PR DESCRIPTION
Hi, I've been playing with your repo trying to get a PER implementation working.
I notice the `SumTree` 's get() method doesn't retrieve data correctly unless the capacity is a power of two because of this logic in the `_retrieve` method:
```python
        left = 2 * idx + 1
        right = left + 1

        if left >= len(self.tree):
            return idx
```
if the tree capacity is not a power of two, the recursion terminates exits at the wrong index (either going past or stopping before where it should).
I've added an assertion to check for this, and a bit of logic to make it easy to set the capacity without having to worry about this